### PR TITLE
feat: setup blog with Astro Content Layer API

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,21 @@
+// src/content.config.ts
+// Configures the content collections for the blog
+// This file is required by Astro's Content Layer API (v5+)
+// RELEVANT FILES: src/pages/blog/[...id].astro, src/content/blog/*.md
+
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  // Load Markdown files from the src/content/blog directory
+  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    heroImage: z.string().optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/hello-world.md
+++ b/src/content/blog/hello-world.md
@@ -1,0 +1,17 @@
+---
+title: "Hello, Astro v5!"
+description: "Astro v5のContent Layer APIを使ってブログを構築しています。"
+pubDate: 2024-01-13
+---
+
+## はじめての投稿
+
+これはAstro v5で新しくなった **Content Layer API** を使用した最初の投稿です。
+
+### なぜContent Layerなのか？
+
+- **パフォーマンス**: 大規模なサイトでもビルドが高速です。
+- **柔軟性**: Markdownだけでなく、JSONや外部APIからもデータを取得できます。
+- **型安全**: Zodによる強力なスキーマ検証が可能です。
+
+これからこのブログをさらに拡張していきましょう。

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,0 +1,44 @@
+---
+// src/layouts/BlogPost.astro
+// Layout for individual blog post pages
+// Formats the blog post metadata and provides a container for the content
+// RELEVANT FILES: src/pages/blog/[...id].astro, src/content.config.ts
+
+import Layout from './Layout.astro';
+import type { CollectionEntry } from 'astro:content';
+
+type Props = CollectionEntry<'blog'>['data'];
+
+const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
+---
+
+<Layout title={title}>
+  <article class="container mx-auto max-w-3xl p-4">
+    {heroImage && (
+      <img
+        src={heroImage}
+        alt=""
+        class="w-full h-auto rounded-lg shadow-md mb-8"
+      />
+    )}
+    <div class="mb-8">
+      <h1 class="text-4xl font-bold mb-2">{title}</h1>
+      <div class="text-gray-600">
+        <time datetime={pubDate.toISOString()}>
+          {pubDate.toLocaleDateString('ja-JP')}
+        </time>
+        {updatedDate && (
+          <span class="ml-4">
+            (更新日: <time datetime={updatedDate.toISOString()}>{updatedDate.toLocaleDateString('ja-JP')}</time>)
+          </span>
+        )}
+      </div>
+    </div>
+    <div class="prose prose-lg max-w-none">
+      <slot />
+    </div>
+    <div class="mt-12 pt-8 border-t">
+      <a href="/" class="text-blue-600 hover:underline">← ホームに戻る</a>
+    </div>
+  </article>
+</Layout>

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,0 +1,24 @@
+---
+// src/pages/blog/[...id].astro
+// Dynamic route for individual blog posts
+// Fetches the post data based on the 'id' and renders it using BlogPost layout
+// RELEVANT FILES: src/content.config.ts, src/layouts/BlogPost.astro
+
+import { getCollection, render } from 'astro:content';
+import BlogPost from '../../layouts/BlogPost.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { id: post.id },
+    props: post,
+  }));
+}
+
+const post = Astro.props;
+const { Content } = await render(post);
+---
+
+<BlogPost {...post.data}>
+  <Content />
+</BlogPost>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,14 +1,43 @@
 ---
 // src/pages/index.astro
 // The landing page of the blog
-// Serves as the entry point for visitors
-// RELEVANT FILES: src/layouts/Layout.astro
+// Lists all blog posts sorted by publication date
+// RELEVANT FILES: src/layouts/Layout.astro, src/content.config.ts
 
 import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog')).sort(
+	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
 ---
 
-<Layout title="Welcome to Astro">
-	<main class="container mx-auto p-4">
-		<h1 class="text-3xl font-bold text-blue-600">Welcome to Astro with Tailwind CSS</h1>
+<Layout title="Astro Blog">
+	<main class="container mx-auto p-4 max-w-4xl">
+		<header class="mb-12 text-center">
+			<h1 class="text-5xl font-extrabold text-gray-900 mb-4">Astro Blog</h1>
+			<p class="text-xl text-gray-600">Astro v5 & Tailwind CSS で構築された個人ブログ</p>
+		</header>
+
+		<section>
+			<h2 class="text-2xl font-bold mb-6 border-b pb-2">最新の投稿</h2>
+			<ul class="space-y-8">
+				{posts.map((post) => (
+					<li class="group">
+						<a href={`/blog/${post.id}/`} class="block">
+							<time datetime={post.data.pubDate.toISOString()} class="text-sm text-gray-500">
+								{post.data.pubDate.toLocaleDateString('ja-JP')}
+							</time>
+							<h3 class="text-2xl font-semibold text-blue-600 group-hover:underline mt-1">
+								{post.data.title}
+							</h3>
+							<p class="text-gray-600 mt-2 line-clamp-2">
+								{post.data.description}
+							</p>
+						</a>
+					</li>
+				))}
+			</ul>
+		</section>
 	</main>
 </Layout>


### PR DESCRIPTION
## Summary
Sets up the initial blog infrastructure using Astro v5 Content Layer API.

## Changes
- Defined `blog` collection in `src/content.config.ts`
- Added `BlogPost` layout and dynamic routing for posts
- Updated homepage to list blog posts
- Added sample content