### PR TITLE
ci: install Playwright with --with-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,8 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Install Playwright OS dependencies
-        run: pnpm pw:install-deps
-
-      - name: Install Playwright browsers
-        run: pnpm pw:install
+      - name: Install Playwright (Chromium + OS deps)
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: a11y tests
         run: pnpm test:a11y


### PR DESCRIPTION
## Summary
- Make Playwright setup in GitHub Actions more reliable by using `playwright install --with-deps chromium`.

## Why
- Reduces CI flakiness by ensuring OS deps and browser are installed together on Ubuntu runners.