### PR TITLE
ci: fix pnpm setup in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,8 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Install Playwright OS dependencies
-        run: pnpm pw:install-deps
-
-      - name: Install Playwright browsers
-        run: pnpm pw:install
+      - name: Install Playwright (Chromium + OS deps)
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: a11y tests
         run: pnpm test:a11y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.12.0
-          cache: pnpm
 
       - name: Enable Corepack
         run: corepack enable
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Fix GitHub Actions setup where `actions/setup-node` fails because `pnpm` isn't available when using built-in pnpm caching.
- Cache pnpm store via `actions/cache` after enabling Corepack.

## Why
- Prevents CI from failing early with "Unable to locate executable file: pnpm".