### PR TITLE
feat: RSS, categories, and TOC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Package manager: `pnpm`（`pnpm-lock.yaml`）
 - Module system: ESM（`package.json#type = module`）
 - Node: `24.12.0`（`package.json#volta`）
+- Site URL: `https://satoru.work`（`astro.config.mjs#site`）
 
 Key paths:
 - Routes: `src/pages/`
@@ -23,6 +24,11 @@ Key paths:
 - Content: `src/content/` + `src/content.config.ts`
 - Styles: `src/styles/global.css`
 - Tests (Playwright): `tests/`
+
+Key routes:
+- RSS feed: `/rss.xml`（`src/pages/rss.xml.ts`）
+- Tags: `/tags`, `/tags/[tag]`
+- Categories: `/categories`, `/categories/[category]`
 
 ## Commands (Build / Lint / Test)
 
@@ -133,6 +139,9 @@ CIでは `playwright install --with-deps chromium` を使って OS依存 + Chrom
 
 - 収集設定: `src/content.config.ts`（`defineCollection` + `glob` loader`）
 - schema は `z` を用いて厳密に（例: `pubDate` は `z.coerce.date()`）。
+- Blog frontmatter fields:
+  - required: `title`, `description`, `pubDate`
+  - optional: `updatedDate`, `heroImage`, `category`, `tags`
 
 ### Formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,178 @@
+# AGENTS.md (repo root)
+
+このリポジトリで動作する agentic coding assistant 向けの作業ガイドです。
+スコープ: リポジトリ全体（より深い階層の `AGENTS.md` があればそちらが優先）。
+
+## Communication
+
+- ユーザーとのコミュニケーションは日本語で行う（ユーザーが英語を明示指定した場合は英語に従う）。
+- 推測で書かず、必ずリポジトリ内の実態（`package.json` / 実ファイル）に合わせる。
+
+## Project Summary
+
+- Type: Astro v5 (ESM) + Tailwind CSS v4（`@tailwindcss/vite`）
+- Language: TypeScript（strict）
+- Package manager: `pnpm`（`pnpm-lock.yaml`）
+- Module system: ESM（`package.json#type = module`）
+- Node: `24.12.0`（`package.json#volta`）
+
+Key paths:
+- Routes: `src/pages/`
+- Layouts: `src/layouts/`
+- Components: `src/components/`
+- Content: `src/content/` + `src/content.config.ts`
+- Styles: `src/styles/global.css`
+- Tests (Playwright): `tests/`
+
+## Commands (Build / Lint / Test)
+
+全て repo root で実行。
+
+### Install
+
+- `pnpm install`
+
+### Dev
+
+- `pnpm dev`
+  - Astro dev server: `http://localhost:4321`
+
+### Typecheck
+
+- `pnpm check`（= `astro check`）
+
+### Lint / Format (Biome)
+
+Biome が導入済み（`biome.json`）。
+
+- Lint（フォーマット差分では落とさない方針）: `pnpm lint`（= `biome lint .`）
+- Lint + format + import整理（書き換えあり）: `pnpm lint:fix`（= `biome check . --write`）
+- Format（書き換えあり）: `pnpm format`（= `biome format . --write`）
+
+注意:
+- `biome.json` は `indentStyle=tab`, `lineWidth=100`, JS/TSは `single quotes` + `semicolons`。
+- `files.ignoreUnknown=true` のため、Biomeが知らない拡張子は無視される。
+- `.astro` はテンプレート全体ではなく frontmatter 側中心の取り扱いになるため、lint/formatの適用範囲に注意する（下記参照）。
+
+### Build / Preview
+
+- Build: `pnpm build`（= `astro build`）
+- Preview: `pnpm preview`（= `astro preview`）
+
+### Tests (Playwright a11y)
+
+このリポジトリのテストは Playwright による a11y smoke（axe）です。
+
+- 全テスト実行（CI相当）: `pnpm test` または `pnpm test:a11y`
+  - `pnpm test:a11y` は `pnpm build && playwright test` を実行
+
+特に「単体テスト1本だけ」:
+- 単一ファイル: `pnpm exec playwright test tests/a11y.spec.ts`
+- テスト名フィルタ: `pnpm exec playwright test --grep "home"`
+  - もしくは `pnpm test:a11y -- --grep "home"`（先に `pnpm build` が走る）
+- デバッグ: `pnpm exec playwright test --debug`
+
+Playwrightのインストール:
+- ブラウザ（Chromium）: `pnpm pw:install`
+- Linux OS依存（必要なら）: `pnpm pw:install-deps`
+
+CIでは `playwright install --with-deps chromium` を使って OS依存 + Chromium をまとめて入れる。
+
+### CI 推奨（最低限）
+
+- `pnpm lint && pnpm check && pnpm build && pnpm test:a11y`
+
+## GitHub / Automation
+
+- GitHub Actions:
+  - CI workflow: `.github/workflows/ci.yml`
+  - Auto-merge workflow: `.github/workflows/automerge.yml`
+- Auto-merge:
+  - PR に label `automerge` を付けると auto-merge（squash）が有効化される
+  - マージは required checks（例: `ci`, `Cloudflare Pages`）が green になるまで行われない
+
+## Repo Conventions
+
+### General
+
+- 既存ファイルのスタイル（インデント/クォート/改行）に合わせる。
+- 無関係な整形（drive-by reformat）はしない。
+- 変更は小さく局所的に。
+
+### Imports
+
+- ローカルは相対 import（エイリアス未設定）。
+- Astro APIs は named import を使う（例: `import { getCollection } from 'astro:content';`）。
+- だいたいの順序（.astro frontmatter 内）:
+  1. ローカル layouts/components
+  2. Astro APIs（`astro:content`, `astro/loaders` など）
+  3. ローカル constants/utils
+- TypeScript は type-only import を使う（例: `import type { CollectionEntry } from 'astro:content';`）。
+
+### TypeScript
+
+- Strict を前提にする（unsafe cast を避ける）。
+- `as any` / `@ts-ignore` / `@ts-expect-error` は禁止（根本原因を直す）。
+
+### Naming
+
+- 定数: `UPPER_SNAKE_CASE`（例: `src/consts.ts` の `SITE_TITLE`）
+- 変数/関数: `camelCase`
+- Components / Layouts: `PascalCase.astro`（例: `src/layouts/Layout.astro`）
+- Routes: Astro の慣習に従う（`index.astro`, `[param].astro`, `[...spread].astro`）
+- Content: `src/content/blog/` 配下は kebab-case（例: `hello-world.md`）
+
+### Astro (.astro)
+
+- 先頭に frontmatter（`---`）を置く。
+- `Astro.props` は `interface Props` で形を明示する。
+- 動的ルートは `export async function getStaticPaths()` を使う。
+- Content Layer は `astro:content` を利用する。
+
+### Content Layer
+
+- 収集設定: `src/content.config.ts`（`defineCollection` + `glob` loader`）
+- schema は `z` を用いて厳密に（例: `pubDate` は `z.coerce.date()`）。
+
+### Formatting
+
+- フォーマッタの基準は `biome.json`。
+- `.astro` はタブインデントのファイルがあるため、触るファイルの既存インデントに合わせる。
+- Biome の `.astro` 向け lint は誤検知が出やすい（frontmatter 変数がテンプレートで使われる等）。
+  - このため `biome.json` は `.astro` 向けに `noUnused*` 系などを弱めている。
+- `.astro` テンプレート全体の整形を Biome に期待しない（必要なら別途方針を相談する）。
+
+### Error handling
+
+- 例外を握りつぶさない（空の `catch {}` は禁止）。
+- 設定/コンテンツの不整合は `pnpm check`（astro check）で早期に落とす。
+
+### Comments
+
+- 既存ファイルのコメントスタイルに合わせる。
+- 新規ファイル作成時は、短いヘッダー（事実のみ）を付ける。
+
+### Tailwind / Styling
+
+- Tailwind は `src/styles/global.css` の `@import "tailwindcss";` で導入。
+- `.astro` 内で Tailwind utility を直接使う。
+- スタイルの一括置換や無関係なclass整理はしない。
+
+## pre-commit
+
+- Husky + lint-staged を使用。
+- hook: `.husky/pre-commit`（`pnpm lint-staged`）
+- lint-staged 設定は `package.json#lint-staged` にある。
+  - 一般ファイル: `biome check --write`
+  - `.astro`: `biome format --write` + `biome lint`
+
+## Editor / Tooling Rules
+
+- Cursor rules: `.cursorrules` / `.cursor/rules/` は未検出。
+- Copilot rules: `.github/copilot-instructions.md` は未検出。
+- VS Code 推奨拡張: `.vscode/extensions.json`（Astro 拡張）。
+
+## Notes for this repository
+
+- OpenCode は `opencode.json` を project config として読む。
+- `opencode.json` で MCP 設定を利用可能（例: `mcp.astro_docs`）。

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This repo uses Husky + lint-staged.
 4. Enable auto-merge (squash)
    - Turn on “Allow auto-merge” in GitHub repo settings
    - Add label `automerge` to the PR (workflow enables auto-merge)
+   - Merging is gated by required checks (e.g. `ci`, `Cloudflare Pages`)
 
 ### Review (static checks)
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,8 +5,8 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://example.com',
-  vite: {
-    plugins: [tailwindcss()]
-  }
+	site: 'https://satoru.work',
+	vite: {
+		plugins: [tailwindcss()],
+	},
 });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"astro": "astro"
 	},
 	"dependencies": {
+		"@astrojs/rss": "^4.0.14",
 		"@tailwindcss/vite": "^4.1.18",
 		"astro": "^5.16.9",
 		"tailwindcss": "^4.1.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/rss':
+        specifier: ^4.0.14
+        version: 4.0.14
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -72,6 +75,9 @@ packages:
   '@astrojs/prism@3.3.0':
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/rss@4.0.14':
+    resolution: {integrity: sha512-KCe1imDcADKOOuO/wtKOMDO/umsBD6DWF+94r5auna1jKl5fmlK9vzf+sjA3EyveXA/FoB3khtQ/u/tQgETmTw==}
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -1119,6 +1125,10 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-parser@5.3.3:
+    resolution: {integrity: sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1817,6 +1827,9 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+
   svgo@4.0.0:
     resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
     engines: {node: '>=16'}
@@ -2279,6 +2292,11 @@ snapshots:
   '@astrojs/prism@3.3.0':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/rss@4.0.14':
+    dependencies:
+      fast-xml-parser: 5.3.3
+      piccolore: 0.1.3
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -3233,6 +3251,10 @@ snapshots:
       micromatch: 4.0.8
 
   fast-uri@3.1.0: {}
+
+  fast-xml-parser@5.3.3:
+    dependencies:
+      strnum: 2.1.2
 
   fastq@1.20.1:
     dependencies:
@@ -4206,6 +4228,8 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  strnum@2.1.2: {}
 
   svgo@4.0.0:
     dependencies:

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -26,6 +26,9 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
 
+<!-- Feeds -->
+<link rel="alternate" type="application/rss+xml" title={title} href={new URL('/rss.xml', Astro.site)} />
+
 <!-- Primary Meta Tags -->
 <title>{title}</title>
 <meta name="title" content={title} />

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -7,16 +7,17 @@ import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
 const blog = defineCollection({
-  // Load Markdown files from the src/content/blog directory
-  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    pubDate: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    heroImage: z.string().optional(),
-    tags: z.array(z.string()).optional(),
-  }),
+	// Load Markdown files from the src/content/blog directory
+	loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+	schema: z.object({
+		title: z.string(),
+		description: z.string(),
+		pubDate: z.coerce.date(),
+		updatedDate: z.coerce.date().optional(),
+		heroImage: z.string().optional(),
+		category: z.string().optional(),
+		tags: z.array(z.string()).optional(),
+	}),
 });
 
 export const collections = { blog };

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,11 +6,16 @@
 
 import Layout from './Layout.astro';
 import TagList from '../components/TagList.astro';
+import type { MarkdownHeading } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 
-type Props = CollectionEntry<'blog'>['data'];
+type Props = CollectionEntry<'blog'>['data'] & {
+	category?: string;
+	headings?: MarkdownHeading[];
+};
 
-const { title, description, pubDate, updatedDate, heroImage, tags } = Astro.props;
+const { title, description, pubDate, updatedDate, heroImage, tags, category, headings } =
+	Astro.props;
 ---
 
 <Layout title={title} description={description} image={heroImage}>
@@ -33,10 +38,39 @@ const { title, description, pubDate, updatedDate, heroImage, tags } = Astro.prop
             (更新日: <time datetime={updatedDate.toISOString()}>{updatedDate.toLocaleDateString('ja-JP')}</time>)
           </span>
         )}
+        {category && (
+          <span class="px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full">
+            <a href={`/categories/${encodeURIComponent(category)}`} class="hover:underline">
+              {category}
+            </a>
+          </span>
+        )}
       </div>
       {tags && tags.length > 0 && <TagList tags={tags} />}
     </div>
     <div class="prose prose-lg max-w-none">
+      {headings && headings.length > 0 && (
+        <nav aria-label="目次" class="mb-8">
+          <div class="bg-gray-50 rounded-lg p-4 border border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-900 mb-3">目次</h2>
+            <ul class="space-y-2">
+              {headings
+                .filter((heading) => heading.depth >= 2 && heading.depth <= 3)
+                .map((heading) => (
+                  <li>
+                    <a
+                      href={`#${heading.slug}`}
+                      class="text-gray-700 hover:text-gray-900 hover:bg-gray-100 inline-block px-2 py-1 rounded transition-colors duration-200"
+                    >
+                      {heading.text}
+                    </a>
+                  </li>
+                ))
+              }
+            </ul>
+          </div>
+        </nav>
+      )}
       <slot />
     </div>
     <div class="mt-12 pt-8 border-t">

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -8,17 +8,17 @@ import { getCollection, render } from 'astro:content';
 import BlogPost from '../../layouts/BlogPost.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
-  return posts.map((post) => ({
-    params: { id: post.id },
-    props: post,
-  }));
+	const posts = await getCollection('blog');
+	return posts.map((post) => ({
+		params: { id: post.id },
+		props: post,
+	}));
 }
 
 const post = Astro.props;
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
 ---
 
-<BlogPost {...post.data}>
+<BlogPost {...post.data} headings={headings}>
   <Content />
 </BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -10,7 +10,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import TagList from '../../components/TagList.astro';
 
 const posts = (await getCollection('blog')).sort(
-    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
 ---
 
@@ -37,6 +37,15 @@ const posts = (await getCollection('blog')).sort(
                                     {post.data.description}
                                 </p>
                             </a>
+                            {post.data.category && (
+                                <div class="mt-2">
+                                    <span class="px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full">
+                                        <a href={`/categories/${encodeURIComponent(post.data.category)}`} class="hover:underline">
+                                            {post.data.category}
+                                        </a>
+                                    </span>
+                                </div>
+                            )}
                             {post.data.tags && post.data.tags.length > 0 && (
                                 <TagList tags={post.data.tags} />
                             )}

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -1,0 +1,63 @@
+---
+// src/pages/categories/[category].astro
+// Dynamic route for displaying blog posts associated with a specific category
+// Helps users find related content efficiently
+// RELEVANT FILES: src/layouts/Layout.astro, src/content.config.ts
+
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+	const allPosts = await getCollection('blog');
+	const uniqueCategories = [
+		...new Set(allPosts.flatMap((post) => (post.data.category ? [post.data.category] : []))),
+	];
+
+	return uniqueCategories.map((category) => {
+		const filteredPosts = allPosts
+			.filter((post) => post.data.category === category)
+			.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+		return {
+			params: { category: encodeURIComponent(category) },
+			props: { category, posts: filteredPosts },
+		};
+	});
+}
+
+const { posts, category } = Astro.props;
+---
+
+<Layout title={`カテゴリー: ${category}`} description={`「${category}」カテゴリーが付いた記事の一覧です。`}>
+  <div class="max-w-3xl mx-auto">
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold">
+        カテゴリー: <span class="text-blue-600">{category}</span>
+      </h1>
+      <p class="text-gray-600 mt-2">{posts.length} 件の記事が見つかりました</p>
+    </div>
+
+    <ul class="space-y-8">
+      {
+        posts.map((post) => (
+          <li class="group">
+            <a href={`/blog/${post.id}/`} class="block">
+              <time datetime={post.data.pubDate.toISOString()} class="text-sm text-gray-500">
+                {post.data.pubDate.toLocaleDateString('ja-JP')}
+              </time>
+              <h2 class="text-2xl font-bold group-hover:text-blue-600 transition-colors">
+                {post.data.title}
+              </h2>
+              <p class="text-gray-600 mt-2 line-clamp-2">
+                {post.data.description}
+              </p>
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+
+    <div class="mt-12 pt-8 border-t">
+      <a href="/categories" class="text-blue-600 hover:underline">← すべてのカテゴリーを見る</a>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -1,0 +1,41 @@
+---
+// src/pages/categories/index.astro
+// Page that displays a list of all categories used in the blog
+// Allows users to discover content by browsing through available categories
+// RELEVANT FILES: src/layouts/Layout.astro, src/components/TagList.astro
+
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = await getCollection('blog');
+const categories = [
+	...new Set(posts.flatMap((post) => (post.data.category ? [post.data.category] : []))),
+].sort();
+---
+
+<Layout title="カテゴリー一覧" description="ブログで使用されているすべてのカテゴリーの一覧です。">
+  <div class="max-w-3xl mx-auto">
+    <h1 class="text-3xl font-bold mb-8">カテゴリー一覧</h1>
+    
+    {categories.length > 0 ? (
+      <div class="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
+        <div class="flex flex-wrap gap-2">
+          {categories.map((category) => (
+            <a
+              href={`/categories/${encodeURIComponent(category)}`}
+              class="px-3 py-1 bg-gray-100 text-gray-700 text-sm rounded-full hover:bg-gray-200 hover:text-gray-900 transition-colors"
+            >
+              {category}
+            </a>
+          ))}
+        </div>
+      </div>
+    ) : (
+      <p class="text-gray-500">カテゴリーがまだありません。</p>
+    )}
+    
+    <div class="mt-12">
+      <a href="/" class="text-blue-600 hover:underline">← ホームに戻る</a>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,26 @@
+import { getCollection } from 'astro:content';
+import rss from '@astrojs/rss';
+import type { APIRoute } from 'astro';
+
+import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
+
+export const prerender = true;
+
+export const GET: APIRoute = async (context) => {
+	const posts = (await getCollection('blog')).sort(
+		(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+	);
+
+	return rss({
+		title: SITE_TITLE,
+		description: SITE_DESCRIPTION,
+		site: context.site ?? new URL('https://satoru.work'),
+		items: posts.map((post) => ({
+			title: post.data.title,
+			description: post.data.description,
+			pubDate: post.data.pubDate,
+			link: `/blog/${post.id}/`,
+			categories: post.data.tags ?? [],
+		})),
+	});
+};


### PR DESCRIPTION
## Summary
- Add `/rss.xml` feed generation and auto-discovery link in `<head>`.
- Add category browsing routes (`/categories`, `/categories/[category]`) and optional `category` frontmatter support.
- Add per-post Table of Contents (h2/h3) using Markdown headings.
- Set site URL to `https://satoru.work` for canonical/feed URLs.

## Notes
- Categories pages are generated only for posts with `category` set.
- Tests run: `pnpm lint && pnpm check && pnpm build && pnpm test:a11y`.